### PR TITLE
Fix Enrollment spelling, add EF Core package, and config

### DIFF
--- a/src/UniversitySystem.Domain/Entities/Course.cs
+++ b/src/UniversitySystem.Domain/Entities/Course.cs
@@ -49,7 +49,7 @@ public class Course : BaseEntity
     public Specialization Specialization { get; set; } = default!;
     public ICollection<Schedule> Schedules { get; set; } = new List<Schedule>();
     public ICollection<Lecture> Lectures { get; set; } = new List<Lecture>();
-    public ICollection<Enrollement> Enrollements { get; set; } = new List<Enrollement>();
+    public ICollection<Enrollment> Enrollements { get; set; } = new List<Enrollment>();
     public ICollection<Grade> Grades { get; set; } = new List<Grade>();
     public ICollection<CourseInstructor> CourseInstructors { get; set; } = new List<CourseInstructor>();
     public ICollection<Evaluation> Evaluations { get; set; } = new List<Evaluation>();

--- a/src/UniversitySystem.Infrastructure/Persistence/Configurations/SpecializationConfiguration.cs
+++ b/src/UniversitySystem.Infrastructure/Persistence/Configurations/SpecializationConfiguration.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using UniversitySystem.Domain.Entities;
+
+namespace UniversitySystem.Infrastructure.Persistence.Configurations
+{
+    public class SpecializationConfiguration : IEntityTypeConfiguration<Specialization>
+    {
+        public void Configure(EntityTypeBuilder<Specialization> builder)
+        {
+            //builder.ToTable("Specializations");
+
+            builder.Property(u => u.Name)
+                   .HasMaxLength(100)
+                   .IsRequired();
+
+            builder.HasOne(s => s.Department)
+                   .WithMany(d => d.Specializations)
+                   .HasForeignKey(s => s.DepartmentId)
+                   .IsRequired()
+                   .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasMany(s => s.Students)
+                   .WithOne(s => s.Specialization)
+                   .HasForeignKey(s => s.SpecializationId)
+                   .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/src/UniversitySystem.Infrastructure/UniversitySystem.Infrastructure.csproj
+++ b/src/UniversitySystem.Infrastructure/UniversitySystem.Infrastructure.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\UniversitySystem.Application\UniversitySystem.Application.csproj" />
     <ProjectReference Include="..\UniversitySystem.Domain\UniversitySystem.Domain.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fix Enrollment spelling, add EF Core package, and config

Updated the `Course` class to correct the spelling of the `Enrollment` property.
Added a package reference for `Microsoft.EntityFrameworkCore` version `9.0.6` in the project file.
Introduced a new `SpecializationConfiguration` class to define entity configurations for the `Specialization` entity, including property constraints and relationships.